### PR TITLE
Add a mechanism to match different patch versions on Gerrit

### DIFF
--- a/src/git.py
+++ b/src/git.py
@@ -23,6 +23,8 @@ import message_dao
 from message import lore_link, Message
 from patch_parser import Patch, Patchset
 from absl import logging
+from typing import Optional
+from patch_associator import PatchAssociator, SimplePatchAssociator
 
 def _git(verb: str, *args, cwd=None, input=None) -> str:
     logging.debug('Running\ngit %s %s\n with input: %s', verb, ' '.join(args), input)
@@ -100,7 +102,7 @@ class GerritGit(object):
             self._git('am', '--abort')
             raise
 
-    def _set_trailers(self, patch: Patch) -> str:
+    def _set_trailers(self, patch: Patch, previous_version: Optional[Message]) -> str:
         """Assuming `patch` is HEAD, edits the commit message before we upload to Gerrit.
 
         Note: normally, we'd rely on a commit-msg or applypatch-msg hook for this.
@@ -114,8 +116,11 @@ class GerritGit(object):
 
         # Set a deterministic Change-Id so we don't create duplicate changes.
         # See https://gerrit-review.googlesource.com/Documentation/user-changeid.html
-        sha1 = hashlib.sha1(patch.message_id.encode()).hexdigest()
-        change_id_trailer = f'Change-Id: I{sha1}'
+        if previous_version is None:
+            change_id = hashlib.sha1(patch.message_id.encode()).hexdigest()
+        else:
+            change_id = previous_version.change_id
+        change_id_trailer = f'Change-Id: I{change_id}'
         lore_trailer = 'Lore-Link: ' + lore_link(patch.message_id)
 
         # Add trailers, changing them if they exist.
@@ -135,9 +140,9 @@ class GerritGit(object):
             logging.warning('Failed to push upstream because %s.', e.output)
             raise
 
-    def _push_patch(self, patch: Patch) -> Patch:
+    def _push_patch(self, patch: Patch, previous_version: Optional[Message]) -> Patch:
         self._apply_patch(patch)
-        self._set_trailers(patch)
+        self._set_trailers(patch, previous_version)
         gerrit_output = self._push_changes()
         change_id = _parse_gerrit_patch_push(gerrit_output)
         patch.change_id = change_id
@@ -162,7 +167,8 @@ class GerritGit(object):
         for patch in patchset.patches:
             # This should cause the server to clean up the git dir because of potential failures
             try:
-                message.change_id = self._push_patch(patch).change_id
+                previous_version = patch_associator.get_previous_version(message)
+                message.change_id = self._push_patch(patch, previous_version).change_id
                 message_dao.store(message)
             except:
                 self._cleanup_git_dir()

--- a/src/main.py
+++ b/src/main.py
@@ -27,6 +27,7 @@ import patch_parser
 from archive_converter import ArchiveMessageIndex
 from message import Message
 from message_dao import MessageDao
+from patch_associator import PatchAssociator, SimplePatchAssociator
 from typing import Collection, Dict, List, Set, Tuple
 
 GIT_PATH = '../linux-kselftest/git/0.git'
@@ -40,7 +41,7 @@ WAIT_TIME = 10
 #TODO(@willliu): consider adding more specific errors to raise, instead of a catch-all
 
 class Server(object):
-    def __init__(self, message_dao : MessageDao) -> None:
+    def __init__(self, message_dao : MessageDao, patch_associator: PatchAssociator) -> None:
         rest = gerrit.get_gerrit_rest_api(COOKIE_JAR_PATH, GERRIT_URL)
         self.gerrit = gerrit.Gerrit(rest)
         self.gerrit_git = git.GerritGit(git_dir='gerrit_git_dir',
@@ -49,6 +50,7 @@ class Server(object):
                                         project='linux/kernel/git/torvalds/linux',
                                         branch='master')
         self.message_dao = message_dao
+        self.patch_associator = patch_associator
         self.archive_index = ArchiveMessageIndex(self.message_dao)
         self.last_hash = self.message_dao.get_last_hash()
         archive_updater.setup_archive(GIT_PATH)
@@ -112,7 +114,8 @@ class Server(object):
                     parent = self.message_dao.get(message.in_reply_to)
                 messages_with_new_comments[parent.id] = parent
 
-        self.upload_messages(messages_to_upload)
+        # Sort messages so that older versions are uploaded first
+        messages_to_upload.sort(key=lambda x : x.subject)
 
         self.upload_comments(messages_with_new_comments)
 
@@ -132,7 +135,7 @@ class Server(object):
         for email_thread in messages_to_upload:
             try:
                 patchset = patch_parser.parse_comments(email_thread)
-                self.gerrit_git.apply_patchset_and_cleanup(patchset, email_thread, self.message_dao)
+                self.gerrit_git.apply_patchset_and_cleanup(patchset, email_thread, self.message_dao, self.patch_associator)
                 gerrit.find_and_label_all_revision_ids(self.gerrit, patchset)
                 gerrit.upload_all_comments(self.gerrit, patchset)
             except Exception as e:
@@ -172,7 +175,9 @@ class Server(object):
             logging.warning('Failed to upload %d/%d replies', failed, len(replies))
 
 def main(argv) -> None:
-    server = Server(MessageDao(GIT_PATH))
+    message_dao = MessageDao(GIT_PATH)
+    patch_associator = SimplePatchAssociator(message_dao, GIT_PATH)
+    server = Server(message_dao, patch_associator)
     server.run()
 
 

--- a/src/message.py
+++ b/src/message.py
@@ -49,6 +49,12 @@ class Message(object):
              raise ValueError(f'Missing patch index in subject: {self.subject}')
          return self._patch_index()
 
+    def version(self) -> int:
+        match = re.match(r'\[.+ v(\d+).*\]', self.subject)
+        if match:
+            return int(match.group(1))
+        return 1
+
     def _patch_index(self) -> Tuple[int, int]:
         match = re.match(r'\[.+ (\d+)/(\d+)\] .+', self.subject)
         if match:

--- a/src/patch_associator.py
+++ b/src/patch_associator.py
@@ -1,0 +1,60 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import abc
+import re
+import subprocess
+
+from typing import Dict, List, Optional
+from message import Message
+from patch_parser import Patch
+from message_dao import MessageDao
+
+class PatchAssociator(object, metaclass = abc.ABCMeta):
+    def __init__(self, message_dao : MessageDao) -> None:
+        self._message_dao = message_dao
+
+    @abc.abstractmethod
+    def get_previous_version(self, message : Message) -> Optional[Message]:
+        pass
+
+class SimplePatchAssociator(PatchAssociator):
+
+    def __init__(self, message_dao: MessageDao, git_path: str) -> None:
+        super().__init__(message_dao)
+        self.git_path = git_path
+
+    def get_time(self, message: Message):
+        return int(subprocess.check_output(
+            ['git', '-C', self.git_path , 'show', '-s', '--format=%ct', message.archive_hash]))
+
+    def newest_first(self, candidates: List[Message]):
+        candidates_with_time = [(message, self.get_time(message)) for message in candidates]
+        # sort by newest commit to latest commit
+        candidates_with_time.sort(key=lambda x: -x[1])
+        return [message for (message, time) in candidates_with_time]
+
+    def get_previous_version(self, message: Message) -> Optional[Message]:
+        candidates = self._message_dao.previous_version_candidates(message)
+        candidates = self.newest_first(candidates)
+        previous_version_number = message.version() - 1
+        compiled = re.compile(fr'\[.+ v{previous_version_number}.*\]')
+        for candidate in candidates:
+            if compiled.match(candidate.subject):
+                return candidate
+            if previous_version_number == 1:
+                # Consider subjects that don't have a version number
+                compiled_no_version = re.compile(fr"\[PATCH\]")
+                if compiled_no_version.match(candidate.subject):
+                    return candidate
+        return None


### PR DESCRIPTION
Creates a Class 'PatchAssociator' that acts as a interface for tracking
the versions such that other heuristics/models can be used to develop
the associator. The 'SimplePatchAssociator' only looks at the subject
(excluding the patch information inside the brackets) for an
exact match of a previous version.